### PR TITLE
Postbit duplicated awards fix

### DIFF
--- a/Upload/inc/plugins/ougc_awards.php
+++ b/Upload/inc/plugins/ougc_awards.php
@@ -1938,12 +1938,19 @@ function ougc_awards_postbit(&$post)
 	$viewall = '';
 
 	$total = count($awardlist);
+	$processed_awards = [];
 
 	foreach($awards_cache['categories'] as $cid => $category)
 	{
 		// Format the awards
 		foreach($awardlist as $award)
 		{
+			if($processed_awards[$award['aid']] == $award['aid']) {
+				continue;
+			}
+
+			$processed_awards[$award['aid']] = $award['aid'];
+
 			$award['aid'] = (int)$award['aid'];
 			if($name = $awards->get_award_info('name', $award['aid']))
 			{


### PR DESCRIPTION
Saw and received a few reports that awards are duplicated on postbit because of the categories.

Turned this:
![image](https://user-images.githubusercontent.com/48567607/65430129-ae378900-de17-11e9-8538-c4370cd991f3.png)

Into this:
![image](https://user-images.githubusercontent.com/48567607/65430085-952ed800-de17-11e9-82fd-a4c077c65514.png)